### PR TITLE
Bumped support to doctrine/persistence >=1.3.4 and 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
     "sonata-project/admin-bundle": "^3.48 | ^4.0",
     "sonata-project/doctrine-orm-admin-bundle": "^3.9 | ^4.0"
   },
+  "conflict": {
+      "doctrine/persistence": "<1.3.4"
+  },
   "autoload": {
     "psr-4": {
       "JarJobs\\SonataDtoModelManager\\": "src/"

--- a/src/Model/AbstractDtoModelManager.php
+++ b/src/Model/AbstractDtoModelManager.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace JarJobs\SonataDtoModelManager\Model;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\ObjectManager;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\DBAL\DBALException;
 use Doctrine\ORM\EntityRepository;


### PR DESCRIPTION
As `sonata-project/admin-bundle` and `sonata-project/doctrine-orm-admin-bundle` support `doctrine/persistence` (`^1.3.4 || ^2.0`). And the current version isn't compatible with version `2`.